### PR TITLE
Fix opening links on macos

### DIFF
--- a/open-issues-for-repo
+++ b/open-issues-for-repo
@@ -3,7 +3,7 @@
 import sys
 import subprocess
 
-from tig_helpers import get_site, get_github_user_and_repo, get_origin_url
+from tig_helpers import get_site, get_github_user_and_repo, get_origin_url, open_url
 
 def main():
 	origin_url = get_origin_url()
@@ -14,8 +14,7 @@ def main():
 	elif site == "chromium.googlesource.com":
 		project    = origin_url.replace("https://chromium.googlesource.com/", "", 1).split("/")[0]
 		url        = "https://bugs.chromium.org/p/%s/issues/list?q=" % (project)
-
-	subprocess.call(["xdg-open", url])
+	open_url(url)
 
 if __name__ == "__main__":
 	main()

--- a/open-links-in-commit-message
+++ b/open-links-in-commit-message
@@ -3,6 +3,8 @@
 import re
 import sys
 import subprocess
+import webbrowser
+import platform
 
 from tig_helpers import get_site, get_github_user_and_repo, get_origin_url
 
@@ -29,6 +31,16 @@ assert get_urls_and_issue_numbers("Fixes#1 GH-2000 http://test/path)") == [1, 20
 assert get_urls_and_issue_numbers("Fixes#1 GH-2000 http://test/path]") == [1, 2000, "http://test/path"]
 assert get_urls_and_issue_numbers("Fixes#1 GH-2000 http://test/path>") == [1, 2000, "http://test/path"]
 
+def open_url(url):
+	if sys.version_info >= (2, 7, 4):
+		webbrowser.open(url)
+	else:
+		plat = platform.system().lower()
+		if plat == 'darwin':
+			subprocess.call(["open", url])
+		else:
+			subprocess.call(["xdg-open", url])
+
 def main():
 	commit     = sys.argv[1]
 	message    = subprocess.check_output(["git", "log", "--format=%B", "-n", "1", commit]).decode("utf-8")
@@ -41,20 +53,20 @@ def main():
 				url = "https://github.com/%s/%s/issues/%d" % (user, repo, url_or_issue)
 			else:
 				url = url_or_issue
-			subprocess.call(["xdg-open", url])
+			open_url(url)
 	elif site == "anonscm.debian.org":
 		for url_or_issue in get_urls_and_issue_numbers(message):
 			if not isinstance(url_or_issue, (str, bytes)):
 				url = "https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=%d" % (url_or_issue,)
 			else:
 				url = url_or_issue
-			subprocess.call(["xdg-open", url])
+			open_url(url)
 	else:
 		for url_or_issue in get_urls_and_issue_numbers(message):
 			# Ignore issue numbers for non-github.com repos
 			if isinstance(url_or_issue, (str, bytes)):
 				url = url_or_issue
-				subprocess.call(["xdg-open", url])
+				open_url(url)
 
 if __name__ == "__main__":
 	main()


### PR DESCRIPTION
Macs don't have `xdg-open`, and `webbrowser` doesn't work on python <2.7.4, so fall back to just using `open` on mac w/ that python version

Test plan:
Running on mac osx 10.15.5 python 2.7.15, chrome browser installed and set as default browser

 - tested `webbrowser` usage by just using it as is
 - commented out `webbrowser` branch and used it to test that `open` works
 - did not test on anything else, but it should be unchanged, I leave it to @ludios to test what they developed on